### PR TITLE
Merge all dependencies

### DIFF
--- a/protop-core/src/main/java/io/protop/core/storage/Storage.java
+++ b/protop-core/src/main/java/io/protop/core/storage/Storage.java
@@ -81,8 +81,9 @@ public class Storage {
 
         PROTOP(".protop"),
 
-        // Is actually nested under .protop
-        DEPS("path");
+        // These are actually nested under .protop
+        PATH("path"),
+        DEPS("deps");
 
         private final String name;
     }

--- a/protop-core/src/main/java/io/protop/core/sync/SyncService.java
+++ b/protop-core/src/main/java/io/protop/core/sync/SyncService.java
@@ -1,5 +1,6 @@
 package io.protop.core.sync;
 
+import com.google.common.collect.ImmutableList;
 import io.protop.core.Context;
 import io.protop.core.auth.AuthService;
 import io.protop.core.cache.CacheService;
@@ -12,15 +13,18 @@ import io.protop.core.storage.StorageService;
 import io.protop.core.sync.status.SyncStatus;
 import io.protop.core.sync.status.Syncing;
 import io.reactivex.Observable;
+import lombok.Getter;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.TrueFileFilter;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 public class SyncService {
 
@@ -47,7 +51,7 @@ public class SyncService {
      */
     public Observable<SyncStatus> sync(DependencyResolutionConfiguration dependencyResolutionConfiguration) {
         return Observable.create(emitter -> {
-            Path dependenciesDir = resolveEmptyDepsDir();
+            Path dependenciesDir = resolveEmptySubDir(Storage.ProjectDirectory.DEPS);
 
             List<DependencyResolver> resolvers = new ArrayList<>();
             if (dependencyResolutionConfiguration.includesLinkedDependencies) {
@@ -71,6 +75,8 @@ public class SyncService {
                 unresolvedDependencies.set(next);
             });
 
+            mergeDepsToPath(dependenciesDir);
+
             Map<Coordinate, RevisionSource> ultimatelyUnresolved = unresolvedDependencies.get();
             if (!ultimatelyUnresolved.isEmpty()) {
                 emitter.onError(new IncompleteSync(ultimatelyUnresolved));
@@ -80,18 +86,125 @@ public class SyncService {
         });
     }
 
-    private Path resolveEmptyDepsDir() throws IOException {
+    private List<File> getProtoFilesInDir(Path dir) {
+        Collection<File> files = FileUtils.listFiles(
+                dir.toFile(), TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
+
+        return files.stream()
+                // For now, assume this is the only extension. If it becomes necessary later, we can
+                // explore allowing custom extensions/patterns to be provided.
+                .filter(file -> file.getName().endsWith(".proto"))
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    @Getter
+    private static class DirectoryWithFiles {
+        private final Map<String, File> files = new HashMap<>();
+        private final Map<String, DirectoryWithFiles> subdirectories = new HashMap<>();
+    }
+
+    private List<File> validProtoFilesOrDirectories(File[] files) {
+        List<String> invalidDirectoryNames = ImmutableList.of("node_modules");
+        List<File> validFiles = new ArrayList<>();
+        for (File file : files) {
+            if (!file.getName().startsWith(".") && !file.isHidden()) {
+                if (file.isDirectory() && !invalidDirectoryNames.contains(file.getName())) {
+                    validFiles.add(file);
+                } else if (file.isFile() && file.getName().endsWith(".proto")) {
+                    validFiles.add(file);
+                }
+            }
+        }
+        return validFiles;
+    }
+
+    /**
+     * Filter the children directories and files and add to the given tree.
+     */
+    private void filterValidChildren(DirectoryWithFiles directoryWithFiles, File path) throws FileAlreadyExistsException {
+        if (path.isDirectory()) {
+            File[] children = Optional.ofNullable(path.listFiles())
+                    .orElse(new File[]{});
+            for (File child : validProtoFilesOrDirectories(children)) {
+                if (child.isDirectory()) {
+                    DirectoryWithFiles childDirectory = directoryWithFiles.subdirectories.computeIfAbsent(
+                            child.getName(),
+                            name -> new DirectoryWithFiles());
+                    filterValidChildren(childDirectory, child);
+                    // If the child directory ended up with nothing in it, remove it.
+                    // This isn't the most efficient thing, but it does save us from having to traverse the
+                    // entire tree again in order to remove empty directories.
+                    if (childDirectory.subdirectories.isEmpty() && childDirectory.files.isEmpty()) {
+                        directoryWithFiles.subdirectories.remove(child.getName());
+                    }
+                } else {
+                    if (directoryWithFiles.files.containsKey(child.getName())) {
+                        String message = String.format(
+                                "Proto file with name %s already exists under parent directory \"%s\"",
+                                child.getName(),
+                                path.getName());
+                        throw new FileAlreadyExistsException(message);
+                    } else {
+                        directoryWithFiles.files.put(child.getName(), child);
+                    }
+                }
+            }
+        } else {
+            throw new RuntimeException("Can not traverse this file since it is not a directory!");
+        }
+    }
+
+    /**
+     * Create subdirectories and symlink files in the given parent.
+     */
+    private void mergeChildrenToParentDirectory(File parent, DirectoryWithFiles children) throws IOException {
+        for (Map.Entry<String, File> fileEntry : children.getFiles().entrySet()) {
+            Files.createSymbolicLink(parent.toPath().resolve(fileEntry.getKey()),
+                    fileEntry.getValue().toPath());
+        }
+        for (Map.Entry<String, DirectoryWithFiles> directoryEntry : children.getSubdirectories().entrySet()) {
+            Path created = Files.createDirectory(parent.toPath().resolve(directoryEntry.getKey()));
+            mergeChildrenToParentDirectory(created.toFile(), directoryEntry.getValue());
+        }
+    }
+
+    private void mergeDepsToPath(Path depsDir) throws IOException {
+        DirectoryWithFiles depsTree = new DirectoryWithFiles();
+        File[] orgs = Optional.ofNullable(depsDir.toFile().listFiles())
+                .orElse(new File[]{});
+        for (File org : orgs) {
+            if (org.isDirectory()) {
+                File[] projects = Optional.ofNullable(org.listFiles())
+                        .orElse(new File[]{});
+                for (File project : projects) {
+                    // For every project, traverse its items and add to the dependency tree.
+                    if (project.isDirectory()) {
+                        filterValidChildren(depsTree, project);
+                    }
+                }
+            }
+        }
+
+        Path mergedDepsPath = resolveEmptySubDir(Storage.ProjectDirectory.PATH);
+        mergeChildrenToParentDirectory(mergedDepsPath.toFile(), depsTree);
+    }
+
+    /**
+     * Generic method to resolve an empty subdirectory (create, or otherwise delete and recreate)
+     * under the .protop directory.
+     */
+    private Path resolveEmptySubDir(Storage.ProjectDirectory dir) throws IOException {
         Path protopPath = context.getProjectLocation()
                 .resolve(Storage.ProjectDirectory.PROTOP.getName());
         storageService.createDirectoryIfNotExists(protopPath)
                 .blockingAwait();
-        Path dependenciesDir = protopPath.resolve(Storage.ProjectDirectory.DEPS.getName());
-        storageService.createDirectoryIfNotExists(dependenciesDir)
+        Path dirPath = protopPath.resolve(dir.getName());
+        storageService.createDirectoryIfNotExists(dirPath)
                 .blockingAwait();
 
         // This is fairly inexpensive and ensures better likelihood of the correct final state of things.
-        FileUtils.cleanDirectory(dependenciesDir.toFile());
+        FileUtils.cleanDirectory(dirPath.toFile());
 
-        return dependenciesDir;
+        return dirPath;
     }
 }


### PR DESCRIPTION
Currently, the resolved dependencies don't have a way of being merged together. That breaks the import paths unless you specifically add each project under `.protop/path/**/*` to the compiler.

This fix move the symlink'd dependencies to `.protop/dep`, and merges all non-hidden directories and `.proto` files together at the top level. For example:

```
.protop/deps:
__orgA
  \__projectA
  |\__a.proto
   \__foo / b.proto
__orgX
  \__projectX
   \__foo / x.proto
```
Would be merged to:
```
.protop/path:
__a.proto
__foo
 |\__b.proto
  \__x.proto
```
